### PR TITLE
Fix orthomesh comment wording

### DIFF
--- a/framework/mesh/orthomesh_generator.h
+++ b/framework/mesh/orthomesh_generator.h
@@ -26,7 +26,7 @@ namespace pdes
 
     /**
      * Creates a 2D orthogonal mesh in the given coordinate system with the
-     * outer product of the give x and y-coordinates.
+     * outer product of the given x and y coordinates.
      */
     static Mesh create_2d_orthomesh(const std::vector<types::real>& x_coords,
                                     const std::vector<types::real>& y_coords,
@@ -48,7 +48,7 @@ namespace pdes
 
     /**
      * Creates a 3D orthogonal mesh in the given coordinate system with the
-     * outer product of the give x, y, and z-coordinates.
+     * outer product of the given x, y, and z coordinates.
      */
     static Mesh create_3d_orthomesh(const std::vector<types::real>& x_coords,
                                     const std::vector<types::real>& y_coords,


### PR DESCRIPTION
## Summary
- clarify 2D orthomesh generator comment
- clarify 3D orthomesh generator comment

## Testing
- `cmake ..` *(fails: Could NOT find MPI)*

------
https://chatgpt.com/codex/tasks/task_e_68997d3bf9d08331882e758518dd0a67