### PR TITLE
Expose diffusion solver solution access

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -41,4 +41,7 @@ main()
   const auto model = DiffusionModel(1.0, k, bcs);
   auto solver = DiffusionSolver(model, fv, linsol, M);
   solver.solve();
+
+  const auto& phi = solver.solution();
+  std::cout << "Solution has " << phi.size() << " entries." << std::endl;
 }

--- a/modules/diffusion/diffusion_solver.h
+++ b/modules/diffusion/diffusion_solver.h
@@ -19,6 +19,9 @@ namespace pdes
     void assemble();
     void solve();
 
+    const Vector<>& solution() const { return x_; }
+    Vector<>& solution() { return x_; }
+
   private:
     const DiffusionModel& model_;
     const std::shared_ptr<SpatialDiscretization> discretization_;


### PR DESCRIPTION
## Summary
- add const/non-const `solution()` accessors to `DiffusionSolver` returning the computed field
- use `solver.solution()` in `main.cc` and print vector size

## Testing
- `cmake -S . -B build` *(fails: Could NOT find MPI)*

------
https://chatgpt.com/codex/tasks/task_e_68997d7273988331b1889e8acfee7864