### PR TITLE
Rebuild preconditioner on assembly

### DIFF
--- a/modules/diffusion/diffusion_solver.cc
+++ b/modules/diffusion/diffusion_solver.cc
@@ -18,7 +18,6 @@ namespace pdes
     x_.reinit(n);
 
     assemble();
-    preconditioner_->build(&A_);
   }
 
   void
@@ -85,6 +84,10 @@ namespace pdes
       } // for cell
     } // if finite volume
     A_.compress();
+
+    // The system matrix has changed; rebuild the preconditioner
+    // before any subsequent solves.
+    preconditioner_->build(&A_);
   }
 
   void

--- a/modules/diffusion/diffusion_solver.h
+++ b/modules/diffusion/diffusion_solver.h
@@ -16,7 +16,16 @@ namespace pdes
                     const std::shared_ptr<LinearSolver<SparseMatrix<>>>& solver,
                     const std::shared_ptr<Preconditioner<SparseMatrix<>>>& preconditioner);
 
+    /**
+     * Assemble the linear system and rebuild the preconditioner.
+     *
+     * Any call to this function must be followed by a preconditioner
+     * rebuild before solving; this requirement is handled internally by
+     * invoking the preconditioner's build routine at the end of the
+     * assembly process.
+     */
     void assemble();
+
     void solve();
 
   private:


### PR DESCRIPTION
## Summary
- Rebuild diffusion preconditioner whenever the matrix is assembled
- Document preconditioner rebuild requirement in the solver API

## Testing
- `cmake -S . -B build` *(fails: Could NOT find MPI)*
- `apt-get update` *(fails: repository ... is not signed)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found!!!)*

------
https://chatgpt.com/codex/tasks/task_e_68997d7ac3448331ad1e38e9b6b1148d